### PR TITLE
ermögliche das Senden des PV-Counters als kWh

### DIFF
--- a/runs/mqttsub.py
+++ b/runs/mqttsub.py
@@ -1324,6 +1324,12 @@ def on_message(client, userdata, msg):
                     f = open('/var/www/html/openWB/ramdisk/soc1', 'w')
                     f.write(msg.payload.decode("utf-8"))
                     f.close()
+            if (msg.topic == "openWB/set/pv/1/kWhCounter"):
+                if (float(msg.payload) >= 0 and float(msg.payload) <= 10000000000):
+                    pvkwhcounter=float(msg.payload.decode("utf-8"))*1000
+                    f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+                    f.write(str(pvkwhcounter))
+                    f.close()
             if (msg.topic == "openWB/set/pv/1/WhCounter"):
                 if (float(msg.payload) >= 0 and float(msg.payload) <= 10000000000):
                     f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
@@ -1337,6 +1343,12 @@ def on_message(client, userdata, msg):
                         pvwatt=int(float(msg.payload.decode("utf-8")))
                     f = open('/var/www/html/openWB/ramdisk/pvwatt', 'w')
                     f.write(str(pvwatt))
+                    f.close()
+            if (msg.topic == "openWB/set/pv/2/kWhCounter"):
+                if (float(msg.payload) >= 0 and float(msg.payload) <= 10000000000):
+                    pvkwhcounter=float(msg.payload.decode("utf-8"))*1000
+                    f = open('/var/www/html/openWB/ramdisk/pvkwh', 'w')
+                    f.write(str(pvkwhcounter))
                     f.close()
             if (msg.topic == "openWB/set/pv/2/WhCounter"):
                 if (float(msg.payload) >= 0 and float(msg.payload) <= 10000000000):


### PR DESCRIPTION
Erlaube das Senden des PV Zählerstandes als kWh-Float (z.B. via Bluetooth von alten SMA-WR und/oder über SBFSpot).
Hierfür wird einfach ein weiteres Topic erstellt (kWhCounter). Die weitere Behandlung ist nicht notwendig, da in der Topicbehandlung direkt wieder zu Wh umgewandelt wird.
Notwendig analog zu #1338, da SBFSpot die Werte nicht vor dem Senden modifizieren kann.